### PR TITLE
chore: add readme reference to homepage property

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tiptap"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/clevertask/scribe",
+  "homepage": "https://github.com/clevertask/scribe#readme",
   "bugs": {
     "url": "https://github.com/clevertask/scribe/issues"
   },


### PR DESCRIPTION
It seems the npm page doesn't show the readme file because of this.