### PR TITLE
Add LaTeX Auto-Detection Plugin with Delimiter Support

### DIFF
--- a/lib/components/Scribe/extension/index.ts
+++ b/lib/components/Scribe/extension/index.ts
@@ -16,6 +16,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import TableHeader from "@tiptap/extension-table-header";
 import { getSuggestionItems } from "./slashCommand/items";
 import { LatexExtension } from "./math-extension";
+import Typography from "@tiptap/extension-typography";
 
 export const initExtensions = (props: ScribeProps) => [
   StarterKit.configure({
@@ -73,4 +74,5 @@ export const initExtensions = (props: ScribeProps) => [
     allowBase64: true,
   }),
   LatexExtension,
+  Typography,
 ];

--- a/lib/components/Scribe/extension/math-extension.ts
+++ b/lib/components/Scribe/extension/math-extension.ts
@@ -69,52 +69,54 @@ export const LatexExtension = Node.create({
             return null;
           }
 
-          const regex = /(\[.*?\])|(\\[a-zA-Z]+(\{[^}]+\})*)/g;
+          const regex = /\$\$([\s\S]+?)\$\$|\$([^\$]+?)\$|\[([^\]]+?)\]|(\\[a-zA-Z]+(?:\{[^}]*\})*)/g;
+
           let tr = newState.tr;
-          let matches: { start: number; end: number; content: string }[] = [];
+          let matches: { start: number; end: number; content: string; isBlock: boolean }[] = [];
 
           newState.doc.descendants((node, pos, parent) => {
-            if (node.isText) {
-              const text = node.text;
-              if (text && parent) {
-                // Skip if inside a code block or inline code
-                if (parent.type.name === "codeBlock" || parent.type.name === "code") {
-                  return;
+            if (!node.isText) return;
+
+            const text = node.text;
+            if (!text || !parent) return;
+
+            // Skip if inside a code block or inline code
+            if (parent.type.name === "codeBlock" || parent.type.name === "code") return;
+
+            // Skip if the text node itself has a code mark
+            if (node.marks.some((mark) => mark.type.name === "code")) return;
+
+            // Skip if already inside a latex node
+            if (parent.type.name === "latex") return;
+
+            if (text.includes("$") || text.includes("[") || text.includes("\\")) {
+              let match;
+              while ((match = regex.exec(text)) !== null) {
+                const [fullMatch, blockDollar, inlineDollar, squareBlock, inlineCommand] = match;
+                const start = pos + match.index;
+                const end = start + fullMatch.length;
+
+                let content = blockDollar || inlineDollar || squareBlock || inlineCommand;
+                const isBlock = !!blockDollar || !!squareBlock;
+                const hasInlineDelimiter = !!inlineDollar;
+
+                // Skip risky commands unless wrapped
+                if (!isBlock && !hasInlineDelimiter && /\\(begin|end|left|right)/.test(content)) {
+                  continue;
                 }
 
-                // Skip if the text node itself has a code mark
-                if (node.marks.some((mark) => mark.type.name === "code")) {
-                  return;
-                }
-
-                // Skip if already inside a latex node
-                if (parent.type.name === "latex") {
-                  return;
-                }
-                let match;
-                while ((match = regex.exec(text)) !== null) {
-                  const fullMatch = match[0];
-                  const start = pos + match.index;
-                  const end = start + fullMatch.length;
-
-                  matches.push({ start, end, content: fullMatch });
-                }
+                matches.push({ start, end, content: content.trim(), isBlock });
               }
             }
           });
 
           if (matches.length > 0) {
-            matches.reverse().forEach(({ start, end, content }) => {
-              const isBlock = content.startsWith("[") && content.endsWith("]");
-              const cleanContent = isBlock
-                ? content.slice(1, -1).trim() // Remove the [ and ] if it's block
-                : content;
-
+            matches.reverse().forEach(({ start, end, content, isBlock }) => {
               tr = tr.replaceWith(
                 start,
                 end,
                 newState.schema.nodes.latex.create({
-                  content: cleanContent,
+                  content,
                   displayMode: isBlock,
                 })
               );

--- a/lib/utils/html-to-markdown.ts
+++ b/lib/utils/html-to-markdown.ts
@@ -9,5 +9,30 @@ export const html2md = (html: string) => {
     codeBlockStyle: "fenced",
   });
 
-  return service.turndown(DOMPurify.sanitize(html));
+  service.addRule("latex", {
+    filter: function (node) {
+      return node.nodeName === "SPAN" && node.getAttribute("data-type") === "latex";
+    },
+    replacement: function (_content, node) {
+      //@ts-ignore
+      const content = node.getAttribute("data-content") || "";
+      //@ts-ignore
+      const isBlock = node.getAttribute("data-display-mode") === "true";
+
+      return isBlock ? `\n\n$$\n${content}\n$$\n\n` : `$${content}$`;
+    },
+  });
+
+  service.addRule("strikethrough", {
+    filter: ["del", "s"],
+    replacement: function (content) {
+      return "~~" + content + "~~";
+    },
+  });
+
+  const patchLatexSpans = (html: string) => {
+    return html.replace(/<span([^>]+data-type="latex"[^>]*)><\/span>/g, "<span$1>•</span>");
+  };
+
+  return service.turndown(DOMPurify.sanitize(patchLatexSpans(html)));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tiptap/extension-table-row": "^2.11.7",
         "@tiptap/extension-task-item": "^2.11.7",
         "@tiptap/extension-task-list": "^2.11.7",
+        "@tiptap/extension-typography": "^2.11.7",
         "@tiptap/pm": "^2.11.7",
         "@tiptap/react": "^2.11.7",
         "@tiptap/starter-kit": "^2.11.7",
@@ -2599,6 +2600,19 @@
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.11.7.tgz",
       "integrity": "sha512-LHO6DBg/9SkCQFdWlVfw9nolUmw+Cid94WkTY+7IwrpyG2+ZGQxnKpCJCKyeaFNbDoYAtvu0vuTsSXeCkgShcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-typography": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-2.11.7.tgz",
+      "integrity": "sha512-qyYROxuXuMAMw30RXFYjr9mfZv+7avD3BW+fVEIa3lwnUMFNExHj6j2HMgYvrPVByGXlQU/4uHWcB0uiG0Bf1w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@tiptap/extension-table-row": "^2.11.7",
     "@tiptap/extension-task-item": "^2.11.7",
     "@tiptap/extension-task-list": "^2.11.7",
+    "@tiptap/extension-typography": "^2.11.7",
     "@tiptap/pm": "^2.11.7",
     "@tiptap/react": "^2.11.7",
     "@tiptap/starter-kit": "^2.11.7",

--- a/src/data.ts
+++ b/src/data.ts
@@ -58,6 +58,63 @@ print(result) # Output: [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
 </code></pre>
 
 <h1>Math expressions</h1>
-<p>\frac{a}{b}\pm\sqrt{x^2+y^2}</p>
-<p>[ \frac{2}{3} \div \frac{4}{5} = \frac{2}{3} \times \frac{5}{4} ] </p>
+<h6>Inline</h6>
+$\alpha$
+$\beta$
+$\pi$
+$x^2 + y^2 = z^2$
+$E = mc^2$
+$\frac{1}{2}$
+$\sqrt{2}$
+$\sum_{i=1}^{n} i$
+$\int_0^1 x^2 dx$
+<h6>Block</h6>
+$$
+\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}
+$$
+
+$$
+\int_{a}^{b} f(x) \, dx = F(b) - F(a)
+$$
+
+$$
+\lim_{x \to 0} \frac{\sin x}{x} = 1
+$$
+
+$$
+\left( \frac{a+b}{c+d} \right)^2
+$$
+
+$$
+\begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix}
+$$
+<h6>Custom block delimiting</h6>
+[ \frac{2}{3} \div \frac{4}{5} = \frac{2}{3} \times \frac{5}{4} ]
+[ \left( \frac{a}{b} \right) ]
+[ \begin{bmatrix} 1 & 2 \\ 3 & 4 \end{bmatrix} ]
+
+<h6>Complex inline math</h6>
+$\left( \frac{a}{b} \right)$
+$\left| x \right|$
+$\left\{ x \in \mathbb{R} \mid x > 0 \right\}$
+$\binom{n}{k}$
+$\vec{v} = (v_x, v_y, v_z)$
+
+<h6>Misc math</h6>
+$A \cup B$
+$A \cap B$
+$A \subseteq B$
+$\forall x \in \mathbb{R},\ x^2 \geq 0$
+$\exists x \in \mathbb{Z},\ x^2 = 2$
+$\theta$
+$\lambda$
+$\mu$
+$\sigma$
+$\omega$
+$\infty$
+$\approx$
+$\neq$
+$\leq$
+$\geq$
+$\Rightarrow$
 `;


### PR DESCRIPTION
**Yeah, the following text is written by AI. It's 2:30 am and I don't have the bandwidth to write about what I did on this PR**

---

## ✨ Add LaTeX Auto-Detection Plugin with Delimiter Support

### 🧠 Summary

This PR introduces a LaTeX auto-detection plugin for the editor that parses and renders LaTeX expressions using KaTeX. It supports both inline and block math expressions and is designed to work seamlessly with AI-generated content and markdown conversion.

---

### ✅ Features

- **Inline and Block Math Support**
  - Supports `$...$` for inline math
  - Supports `$$...$$` and `[ ... ]` for block math
- **KaTeX Rendering**
  - Uses `displayMode` to control block vs inline rendering
  - Gracefully handles invalid LaTeX with KaTeX error fallback
- **Flexible Parsing**
  - Allows simple LaTeX commands without delimiters (e.g. `\frac{1}{2}`)
  - Skips risky expressions like `\left`, `\right`, `\begin`, `\end` unless wrapped in delimiters
- **Markdown Conversion**
  - Converts LaTeX nodes to `$...$` or `$$...$$` in markdown
  - Adds a workaround to ensure empty `<span>` nodes are processed by Turndown
- **AI-Friendly**
  - Designed to work well with AI-generated content by encouraging use of delimiters for complex expressions

---

### 🧪 Examples

| Input | Output |
|-------|--------|
| `$E = mc^2$` | ✅ Inline |
| `$$\int_0^1 x^2 dx$$` | ✅ Block |
| `[ \left( \frac{a}{b} \right) ]` | ✅ Block |
| `\frac{1}{2}` | ✅ Inline |
| `\left( \frac{a}{b} \right)` (no delimiter) | ❌ Skipped (too risky) |

---

### ⚠️ Notes

- While the plugin supports parsing some expressions without delimiters, it's **strongly recommended** to wrap LaTeX expressions in `$...$` or `$$...$$` when using:
  - `\left...\right`
  - `\begin...\end`
  - Any expression with spaces or multiple commands

This ensures the expression is parsed as a whole and avoids KaTeX rendering errors.

---

### 🧼 Implementation Notes

- Added a Turndown rule to convert `<span data-type="latex">` into `$...$` or `$$...$$`
- Injected a dummy character (`•`) into empty LaTeX spans to ensure Turndown processes them
- Cleaned up the dummy character in the final markdown output

---

### 🚀 Next Steps (optional)

- Add support for `\(...\)` and `\[...\]` if needed
- Convert LaTeX notation as I write in the text editor
