### PR TITLE
Add Support for Writing LaTeX with `$...$` and `[ ... ]` Delimiters

### DIFF
--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -53,6 +53,7 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
   const editor = useEditor(
     {
       ...editorProps,
+      editable,
       extensions: [...initExtensions(props), ...(extensions ?? [])],
       onUpdate({ editor }) {
         const htmlContent = editor.getHTML();


### PR DESCRIPTION

## Summary

This PR adds support for writing LaTeX expressions directly in the editor using:

- `$...$` → for **inline** math expressions  
- `[ ... ]` → for **block** math expressions (only if the content starts with a backslash)

This improves the writing experience by allowing users to type LaTeX naturally without needing to insert special nodes manually.

---

### Behavior

- Inline: `$\frac{1}{2}$` → renders as inline math
- Block: `[\frac{1}{2}]` → renders as block math
- Raw LaTeX commands (like `\frac`) are only parsed in **read-only mode**
- In **editable mode**, delimiters are required to avoid premature parsing while typing

---

### Notes

- `[ ... ]` must contain a backslash (`\`) to be considered a LaTeX block
- `$$...$$` is no longer supported while typing, but still works in read-only mode
- This ensures a smooth typing experience while keeping rendering behavior flexible
