### PR TITLE
chore: add partial dark-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ function App() {
 }
 ```
 
+### With Dark Mode
+
+```tsx
+import "@clevertask/scribe/dist/main.css";
+import { Scribe, ScribeOnChangeContents } from "@clevertask/scribe";
+
+function App() {
+  const editor = useRef<ScribeRef>(null);
+
+  const resetContent = useCallback(() => {
+    editor.current.resetContent();
+  }, []);
+
+  return (
+    <>
+      <Scribe darkMode />
+      <button onClick={resetContent}>Reset content</button>
+    </>
+  );
+}
+```
+
 ## Props
 
 | Prop                     | Type                                         | Default                    | Description                                                                                                                                                                                                                                        |
@@ -85,6 +107,7 @@ function App() {
 | `mainContainerStyle`     | `React.CSSProperties`                        | `undefined`                | You can send a CSS object to style the main editor container                                                                                                                                                                                       |
 | `mainContainerClassName` | `string`                                     | `undefined`                | The same idea of `mainContainerStyle` but with classes.                                                                                                                                                                                            |
 | `onKeyDown`              | `KeyboardEventHandler`                       | `undefined`                | A callback function that is triggered when a key is pressed within the editor. This allows you to handle custom keyboard shortcuts. For example, you can use this prop to implement a "send message" functionality when `Ctrl + Enter` is pressed. |
+| `darkMode`               | `boolean`                                    | `false`                    | You can switch the darkMode value to change the text editor's theme                                                                                                                                                                                |
 
 ## Helper Functions
 

--- a/lib/components/Menu/BarMenu.tsx
+++ b/lib/components/Menu/BarMenu.tsx
@@ -15,9 +15,10 @@ import HorizontalLineIcon from "../../icons/horizontal-line.svg";
 
 export interface BarMenuProps {
   editor: Editor;
+  darkMode: boolean;
 }
 
-const BarMenu: FC<BarMenuProps> = ({ editor }) => {
+const BarMenu: FC<BarMenuProps> = ({ editor, darkMode }) => {
   const handleSetLink = useCallback(() => {
     const previousUrl = editor.getAttributes("link").href;
     // const selectedText = editor.commands.getSelectedText() as unknown as
@@ -64,10 +65,7 @@ const BarMenu: FC<BarMenuProps> = ({ editor }) => {
   const handleSetImage = useCallback(() => {
     const existingImage = editor.getAttributes("image").src;
 
-    const url = window.prompt(
-      existingImage ? "Update Image URL" : "Image URL",
-      existingImage,
-    );
+    const url = window.prompt(existingImage ? "Update Image URL" : "Image URL", existingImage);
     if (!url) {
       return;
     }
@@ -171,14 +169,12 @@ const BarMenu: FC<BarMenuProps> = ({ editor }) => {
                     title={item.name}
                     disabled={item?.disabled}
                     key={item.name}
-                    className={`rounded-md ${
-                      item.isActive() ? "bg-gray-100" : ""
-                    } ${
+                    className={`rounded-md ${item.isActive() ? (darkMode ? "bg-gray-800" : "bg-gray-100") : ""} ${
                       item?.disabled ? "cursor-not-allowed bg-opacity-50" : ""
                     }`}
                     onClick={item.command}
                   >
-                    <img src={item.icon} alt={item.name} />
+                    <img src={item.icon} alt={item.name} style={{ filter: `invert(${darkMode ? 1 : 0})` }} />
                   </button>
                 );
               })}

--- a/lib/components/Menu/BarMenu.tsx
+++ b/lib/components/Menu/BarMenu.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { Editor } from "@tiptap/react";
 import { FC, Fragment, useCallback } from "react";
 import BoldIcon from "../../icons/bold.svg";
@@ -158,7 +159,7 @@ const BarMenu: FC<BarMenuProps> = ({ editor, darkMode }) => {
   ];
 
   return (
-    <div className="flex flex-row gap-4 border-b p-[8px]">
+    <div className={clsx("flex flex-row gap-4 border-b p-[8px]", darkMode ? "border-zinc-700" : "border-zinc-200")}>
       {Formats.map((format, index) => {
         return (
           <Fragment key={`format-group-${index}`}>
@@ -169,9 +170,11 @@ const BarMenu: FC<BarMenuProps> = ({ editor, darkMode }) => {
                     title={item.name}
                     disabled={item?.disabled}
                     key={item.name}
-                    className={`rounded-md ${item.isActive() ? (darkMode ? "bg-gray-800" : "bg-gray-100") : ""} ${
+                    className={clsx(
+                      "rounded-md",
+                      item.isActive() ? (darkMode ? "bg-zinc-700" : "bg-zinc-200") : "",
                       item?.disabled ? "cursor-not-allowed bg-opacity-50" : ""
-                    }`}
+                    )}
                     onClick={item.command}
                   >
                     <img src={item.icon} alt={item.name} style={{ filter: `invert(${darkMode ? 1 : 0})` }} />
@@ -179,7 +182,9 @@ const BarMenu: FC<BarMenuProps> = ({ editor, darkMode }) => {
                 );
               })}
             </div>
-            {index !== Formats.length - 1 && <div className="border-l"></div>}
+            {index !== Formats.length - 1 && (
+              <div className={clsx("border-l", darkMode ? "border-zinc-700" : "border-zinc-200")}></div>
+            )}
           </Fragment>
         );
       })}

--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -35,6 +35,7 @@ export interface ScribeProps {
   mainContainerStyle?: React.CSSProperties;
   mainContainerClassName?: ClassValue;
   onKeyDown?: KeyboardEventHandler;
+  darkMode?: boolean;
 }
 
 export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
@@ -52,6 +53,7 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
     mainContainerClassName,
     onKeyDown,
     externalEditor,
+    darkMode,
   } = props;
 
   const editorRef = useRef<Editor | null>(externalEditor || null);
@@ -138,11 +140,16 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
   }, [autoFocus]);
 
   return (
-    <div className={clsx("scribe-wrapper", mainContainerClassName)} style={mainContainerStyle} id="scribe-wrapper">
-      <div className={clsx("bg-white", editable && "rounded-lg border")}>
-        {editor && showBarMenu && <BarMenu editor={editor} />}
+    <div className={clsx("scribe-wrapper", mainContainerClassName)} style={mainContainerStyle}>
+      <div className={clsx(editable && "rounded-lg border")}>
+        {editor && showBarMenu && <BarMenu editor={editor} darkMode={!!darkMode} />}
         <div
-          className={clsx("prose max-w-none", editable && "w-full p-[16px]", editorContentClassName)}
+          className={clsx(
+            "prose max-w-none",
+            editable && "w-full p-[16px]",
+            darkMode && "prose-invert",
+            editorContentClassName
+          )}
           style={editorContentStyle}
         >
           <EditorContent editor={editor} onKeyDown={onKeyDown} />

--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -141,7 +141,7 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
 
   return (
     <div className={clsx("scribe-wrapper", mainContainerClassName)} style={mainContainerStyle}>
-      <div className={clsx(editable && "rounded-lg border")}>
+      <div className={clsx(editable && "rounded-lg border", darkMode ? "border-zinc-700" : "border-zinc-200")}>
         {editor && showBarMenu && <BarMenu editor={editor} darkMode={!!darkMode} />}
         <div
           className={clsx(


### PR DESCRIPTION
This PR adds a prop to toggle the editor theme to dark or light mode. While it's not perfect, this could hotfix some styling issues when using the text editor in dark mode. You can edit the typography variables to adapt the theme to your brand styles: https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#adapting-to-dark-mode

Total theme-mode support will be added in future PRs. ✌🏻 