### PR TITLE
chore: convert legacy math expressions to be compatible with the tiptap math extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ A versatile, block-based rich text editor for diverse applications, built with T
 - [@clevertask/scribe](#clevertaskscribe)
   - [Installation](#installation)
   - [Usage](#usage)
+  - [Math Expressions](#math-expressions)
   - [Props](#props)
   - [Helper Functions](#helper-functions)
     - [md2html](#md2html)
     - [html2md](#html2md)
+    - [convertLegacyMathDelimiters](#convertlegacymathdelimiters)
   - [Roadmap](#roadmap)
   - [Release Process](#release-process)
   - [License](#license)
@@ -38,9 +40,12 @@ import "@clevertask/scribe/dist/main.css";
 import { Scribe, ScribeOnChangeContents } from "@clevertask/scribe";
 
 function App() {
-  const onContentChange = useCallback(({ markdownContent, htmlContent, jsonContent }: ScribeOnChangeContents) => {
-    console.log(markdownContent, htmlContent, jsonContent);
-  }, []);
+  const onContentChange = useCallback(
+    ({ markdownContent, htmlContent, jsonContent }: ScribeOnChangeContents) => {
+      console.log(markdownContent, htmlContent, jsonContent);
+    },
+    [],
+  );
 
   return <Scribe onContentChange={onContentChange} />;
 }
@@ -90,6 +95,35 @@ function App() {
 }
 ```
 
+## Math Expressions
+
+Scribe ships with `@tiptap/extension-mathematics`. The extension renders math when it receives math nodes in the HTML:
+
+```html
+<span data-type="inline-math" data-latex="\alpha"></span>
+<div data-type="block-math" data-latex="\sum_{i=1}^{n} x_i"></div>
+```
+
+### Typing Delimiters (Input Rules)
+
+When typing directly in the editor, the built-in input rules use:
+
+```
+Inline: $$\alpha$$
+Block: $$$\sum_{i=1}^{n} x_i$$$
+```
+
+### Markdown Delimiters
+
+If you are parsing markdown with the Tiptap Markdown extension (not `md2html`), the tokenizer expects:
+
+```
+Inline: $\alpha$
+Block: $$\sum_{i=1}^{n} x_i$$
+```
+
+If your content arrives as HTML (for example from a server), use the helper below to convert legacy delimiters into the HTML nodes that the math extension understands.
+
 ## Props
 
 | Prop                     | Type                                         | Default                    | Description                                                                                                                                                                                                                                        |
@@ -134,7 +168,11 @@ const ChatMessages = () => {
   return messages.map((message) => (
     <Flex key={message.id} direction="column" mb="4">
       <Heading size="4">{`${message.role}: `}</Heading>
-      <Scribe editable={false} showBarMenu={false} content={md2html(message.content)} />
+      <Scribe
+        editable={false}
+        showBarMenu={false}
+        content={md2html(message.content)}
+      />
     </Flex>
   ));
 };
@@ -159,6 +197,44 @@ const md = html2md("<h1>Hello world</h1>"); // Output: # Hello world
 ```
 
 > **Note**: The Scribe component already exposes a property called `markdownContent` when the `onContentChange` is used. In fact, the `markdownContent` is the output of the usage of the `html2md` function.
+
+---
+
+### `convertLegacyMathDelimiters`
+
+```typescript
+export declare function convertLegacyMathDelimiters(input: string): string;
+```
+
+Convert legacy math delimiters into the HTML nodes required by the mathematics extension. This is useful when you receive HTML from a server that contains legacy math like `\(...\)` or `\[...\]`.
+
+This helper is primarily for consumers upgrading from older Scribe versions who stored math expressions using the legacy formats. It aims to be accurate, but the previous format was ambiguous (no explicit `$$` delimiters), so conversion is best-effort and not guaranteed in every case.
+
+**Supported legacy delimiters**:
+
+- `\(...\)` for inline math
+- `\[...\]` for block math
+- `(...)` and `[...]` when the content looks like LaTeX (contains `\`, `^`, or `_`)
+
+**Usage Example**:
+
+```tsx
+import {
+  convertLegacyMathDelimiters,
+  md2html,
+  Scribe,
+} from "@clevertask/scribe";
+
+const html = md2html(convertLegacyMathDelimiters(rawMarkdown));
+
+// OR
+
+const html = convertLegacyMathDelimiters(htmlContent);
+
+<Scribe editable={false} showBarMenu={false} content={html} />;
+```
+
+If you already receive HTML from the server, call `convertLegacyMathDelimiters` directly on that HTML before rendering.
 
 ## Roadmap
 

--- a/lib/utils/convert-legacy-math-delimiters.ts
+++ b/lib/utils/convert-legacy-math-delimiters.ts
@@ -1,0 +1,44 @@
+const escapeAttribute = (value: string) =>
+    value
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
+const renderInline = (latex: string) =>
+    `<span data-type="inline-math" data-latex="${escapeAttribute(latex.trim())}"></span>`;
+
+const renderBlock = (latex: string) =>
+    `<div data-type="block-math" data-latex="${escapeAttribute(latex.trim())}"></div>`;
+
+const isLikelyLatex = (value: string) => /\\[a-zA-Z]+|[_^]/.test(value);
+
+const inlineMathRegex = /\\\(([^\n]+?)\\\)|\\\[([^\n]+?)\\\]|\[([^\n]+?)\]|\(([^\n]+?)\)/g;
+
+const replaceInlineMath = (text: string) =>
+    text.replace(inlineMathRegex, (match, escapedParen, escapedBracket, rawBracket, rawParen) => {
+        const latex = escapedParen || escapedBracket || rawBracket || rawParen || "";
+        const isEscaped = Boolean(escapedParen || escapedBracket);
+
+        if (!isEscaped && !isLikelyLatex(latex)) {
+            return match;
+        }
+
+        return renderInline(latex);
+    });
+
+const replaceInlineInHtml = (input: string) =>
+    input
+        .split(/(<[^>]+>)/g)
+        .map(chunk => (chunk.startsWith("<") ? chunk : replaceInlineMath(chunk)))
+        .join("");
+
+export const convertLegacyMathDelimiters = (input: string) => {
+    const withBlockMath = input.replace(
+        /(^|\n)[ \t]*(?:\\\[|\[)([\s\S]*?)(?:\\\]|\])[ \t]*(?=\n|$)/g,
+        (match, leading, latex) =>
+            isLikelyLatex(latex) ? `${leading}${renderBlock(latex)}` : match,
+    );
+
+    return replaceInlineInHtml(withBlockMath);
+};

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./html-to-markdown";
 export * from "./markdown-to-html";
 export * from "./is-in-viewport";
+export * from './convert-legacy-math-delimiters';
 export * from "./create-scribe-editor";

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prettier:format": "npx prettier . --write"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": ">=18.3.1 <20.0.0",
+    "react-dom": ">=18.3.1 <20.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",


### PR DESCRIPTION
This pull request introduces a helper function that converts math expressions from older versions of Scribe to be compatible with the tiptap math extension added in the previous [pull request](https://github.com/clevertask/scribe/pull/18/changes#diff-7d3f0f54217a290e9fa8e36831e12f0ed32da20ef551753da172a86dcf9dff85R18). While the function is designed to achieve a high level of accuracy, it does not guarantee that all legacy math expressions will be successfully converted to the new format.