### PR TITLE
chore: publish package only on workflow dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,6 @@ name: Publish Package
 
 on:
   workflow_dispatch:
-  release:
-    types: [created]
-  push:
-    tags:
-      - "v*"
 
 permissions:
   id-token: write # Required for OIDC


### PR DESCRIPTION
I've had some weird [issues ](https://github.com/clevertask/scribe/actions/runs/22025002958/job/63640131416)when making a release. That didn't use to happen, so I'll figure it out in a follow-up PR.