### PR TITLE
chore: format markdown on paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A versatile, block-based rich text editor for diverse applications, built with T
 
 - **Block-based Editing:** Enjoy a familiar and intuitive Notion-style editing experience.
 - **Markdown Support:** Parse and render Markdown content effortlessly.
+- **Markdown Paste:** Paste plain-text markdown into the editor and have it converted into rich content automatically.
 - **Versatile Integration:** Easily integrate `@clevertask/scribe` into any project requiring rich text editing.
 - **View and Edit:** Seamlessly switch between viewing and editing modes.
 
@@ -152,6 +153,8 @@ export declare function md2html(md: string): string;
 ```
 
 Convert markdown to html. Useful if you're rendering an AI-based response, or if you were storing content on markdown in your database and want to show it on the text editor. This function sanitizes the content to prevent XSS attacks.
+
+Editable Scribe instances also use this conversion internally when you paste plain-text markdown into the editor.
 
 **Usage Example**:
 

--- a/lib/components/Scribe/extension/extension-markdown-paste.ts
+++ b/lib/components/Scribe/extension/extension-markdown-paste.ts
@@ -1,0 +1,141 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { marked, Token } from "marked";
+import { md2html } from "../../../utils/markdown-to-html";
+
+const markdownPastePluginKey = new PluginKey("markdownPaste");
+
+const blockMarkdownTokenTypes = new Set(["blockquote", "code", "heading", "hr", "list", "table"]);
+const inlineMarkdownTokenTypes = new Set(["codespan", "del", "em", "strong"]);
+
+const hasMarkdownLinkSyntax = (token: Token) => {
+  if (token.type === "image") {
+    return token.raw.startsWith("![");
+  }
+
+  if (token.type === "link") {
+    return token.raw.startsWith("[");
+  }
+
+  return false;
+};
+
+const containsMarkdownTokens = (tokens: Token[]): boolean => {
+  return tokens.some((token) => {
+    if (
+      blockMarkdownTokenTypes.has(token.type) ||
+      inlineMarkdownTokenTypes.has(token.type) ||
+      hasMarkdownLinkSyntax(token)
+    ) {
+      return true;
+    }
+
+    if ("tokens" in token && Array.isArray(token.tokens) && containsMarkdownTokens(token.tokens)) {
+      return true;
+    }
+
+    if ("items" in token && Array.isArray(token.items)) {
+      return token.items.some((item) => containsMarkdownTokens(item.tokens));
+    }
+
+    return false;
+  });
+};
+
+const shouldConvertMarkdownPaste = (clipboardText: string) => {
+  const normalizedText = clipboardText.trim();
+
+  if (!normalizedText) {
+    return false;
+  }
+
+  return containsMarkdownTokens(marked.lexer(normalizedText));
+};
+
+const getTaskListCheckbox = (listItem: HTMLLIElement) => {
+  const firstElementChild = listItem.firstElementChild;
+
+  if (!(firstElementChild instanceof HTMLInputElement) || firstElementChild.type !== "checkbox") {
+    return null;
+  }
+
+  return firstElementChild;
+};
+
+const normalizeTaskListHtml = (html: string) => {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+
+  for (const list of template.content.querySelectorAll("ul")) {
+    const listItems = Array.from(list.children).filter(
+      (child): child is HTMLLIElement => child instanceof HTMLLIElement,
+    );
+
+    if (!listItems.length || listItems.length !== list.children.length) {
+      continue;
+    }
+
+    const checkboxes = listItems.map(getTaskListCheckbox);
+
+    if (checkboxes.some((checkbox) => !checkbox)) {
+      continue;
+    }
+
+    list.setAttribute("data-type", "taskList");
+
+    listItems.forEach((listItem, index) => {
+      const checkbox = checkboxes[index];
+
+      if (!checkbox) {
+        return;
+      }
+
+      const isChecked = checkbox.checked;
+      checkbox.remove();
+      listItem.setAttribute("data-type", "taskItem");
+      listItem.setAttribute("data-checked", isChecked ? "true" : "false");
+
+      if (listItem.firstChild?.nodeType === Node.TEXT_NODE) {
+        listItem.firstChild.textContent =
+          listItem.firstChild.textContent?.replace(/^\s+/, "") ?? "";
+
+        if (!listItem.firstChild.textContent) {
+          listItem.firstChild.remove();
+        }
+      }
+    });
+  }
+
+  return template.innerHTML;
+};
+
+export default Extension.create({
+  name: "markdownPaste",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: markdownPastePluginKey,
+        props: {
+          handlePaste: (_, event) => {
+            const clipboardHtml = event.clipboardData?.getData("text/html");
+            const clipboardText = event.clipboardData?.getData("text/plain");
+
+            if (!clipboardText || clipboardHtml || !shouldConvertMarkdownPaste(clipboardText)) {
+              return false;
+            }
+
+            event.preventDefault();
+            this.editor
+              .chain()
+              .focus()
+              .insertContent(normalizeTaskListHtml(md2html(clipboardText)))
+              .run();
+
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/lib/components/Scribe/extension/index.ts
+++ b/lib/components/Scribe/extension/index.ts
@@ -1,5 +1,6 @@
 import { ScribeProps } from "..";
 import Link from "./extension-link";
+import MarkdownPaste from "./extension-markdown-paste";
 import Focus from "@tiptap/extension-focus";
 import Image from "@tiptap/extension-image";
 import Table from "@tiptap/extension-table";
@@ -59,6 +60,7 @@ export const initExtensions = (props: ScribeProps) => [
     },
   }),
   Focus.configure({ mode: "deepest", className: "has-focus" }),
+  MarkdownPaste,
   SlashCommand.configure({
     slashSuggestion: {
       items: getSuggestionItems,


### PR DESCRIPTION
This PR adds a MarkdownPaste extension. This helps us paste the Markdown test into the Editor so we can format it. I think this Editor used to do that in previous versions, but it doesn't anymore. So, I need to add an explicit extension to keep that behavior.