### PR TITLE
feat(scribe): expose experimental table of contents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A versatile, block-based rich text editor for diverse applications, built with T
 - **Markdown Paste:** Paste plain-text markdown into the editor and have it converted into rich content automatically.
 - **Versatile Integration:** Easily integrate `@clevertask/scribe` into any project requiring rich text editing.
 - **View and Edit:** Seamlessly switch between viewing and editing modes.
-- **Experimental Document Outline:** Subscribe to heading changes and render an app-owned outline outside the editor.
+- **Experimental Table of Contents:** Subscribe to heading changes and render an app-owned table of contents outside the editor.
 
 ## Table of Contents
 
 - [@clevertask/scribe](#clevertaskscribe)
   - [Installation](#installation)
   - [Usage](#usage)
-  - [Experimental Document Outline](#experimental-document-outline)
+  - [Experimental Table of Contents](#experimental-table-of-contents)
   - [Math Expressions](#math-expressions)
   - [Props](#props)
   - [Helper Functions](#helper-functions)
@@ -103,9 +103,9 @@ function App() {
 }
 ```
 
-## Experimental Document Outline
+## Experimental Table of Contents
 
-Scribe can expose a heading outline without rendering table-of-contents content inside the editable document. Enable the experimental API with `enableTableOfContents`, keep the latest items in your app state, and call `scrollToTableOfContentsItem` when a user selects an outline entry.
+Scribe can expose table-of-contents data without rendering a table-of-contents block inside the editable document. Enable the experimental API with `enableTableOfContents`, keep the latest items in your app state, and call `scrollToTableOfContentsItem` when a user selects an entry.
 
 ```tsx
 import { Scribe, ScribeRef, ScribeTableOfContentsItem } from "@clevertask/scribe";
@@ -113,15 +113,19 @@ import { useRef, useState } from "react";
 
 function DocumentEditor() {
   const scribe = useRef<ScribeRef>(null);
-  const [outlineItems, setOutlineItems] = useState<ScribeTableOfContentsItem[]>([]);
+  const [tableOfContentsItems, setTableOfContentsItems] = useState<ScribeTableOfContentsItem[]>([]);
 
   return (
     <>
-      <Scribe ref={scribe} enableTableOfContents onTableOfContentsChange={setOutlineItems} />
+      <Scribe
+        ref={scribe}
+        enableTableOfContents
+        onTableOfContentsChange={setTableOfContentsItems}
+      />
 
-      {outlineItems.length > 0 ? (
-        <nav aria-label="Document outline">
-          {outlineItems.map((item) => (
+      {tableOfContentsItems.length > 0 ? (
+        <nav aria-label="Table of contents">
+          {tableOfContentsItems.map((item) => (
             <button
               key={item.id}
               type="button"
@@ -137,7 +141,7 @@ function DocumentEditor() {
 }
 ```
 
-The outline currently tracks default TipTap heading nodes only. Each item includes the heading text, depth, document position, DOM node, and active/scrolled state. This API is marked experimental while we validate the contract in real document surfaces.
+The table of contents currently tracks default TipTap heading nodes only. Each item includes the heading text, depth, document position, DOM node, and active/scrolled state. This API is marked experimental while we validate the contract in real document surfaces.
 
 ## Math Expressions
 
@@ -172,23 +176,23 @@ If your content arrives as HTML (for example from a server), use the helper belo
 
 ## Props
 
-| Prop                      | Type                                                               | Default                    | Description                                                                                                                                                                                                                                        |
-| ------------------------- | ------------------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`                 | `string`                                                           | `undefined`                | The initial content of the editor. Controlled updates through this prop are deprecated; prefer `ScribeRef.setContent` for programmatic updates after mount.                                                                                        |
-| `onContentChange`         | `(content: ScribeOnChangeContents) => void;`                       | `undefined`                | A callback function triggered whenever the editor's content changes. It receives an object containing the current content in various formats (`jsonContent`, `htmlContent`, `markdownContent`). Internal outline metadata updates are ignored.     |
-| `editable`                | `boolean`                                                          | `true`                     | Controls whether the editor is editable.                                                                                                                                                                                                           |
-| `autoFocus`               | `boolean`                                                          | `false`                    | Controls whether the editor should automatically focus when mounted.                                                                                                                                                                               |
-| `extensions`              | `Extension[]`                                                      | `undefined`                | You can set your own extensions for the text editor. For more information, [check the tip tap extensions docs](https://tiptap.dev/docs/editor/core-concepts/extensions)                                                                            |
-| `editorProps`             | `EditorProps`                                                      | `undefined`                | A tiptap-based prop to handle advanced use cases, you can read about it on their [documentation](https://tiptap.dev/docs/editor/api/editor#editorprops)                                                                                            |
-| `showBarMenu`             | `boolean`                                                          | `true`                     | Determines whether to show the text editor top menu bar or not. This menu bar shows options to format the text                                                                                                                                     |
-| `placeholderText`         | `string`                                                           | `Type "/" for commands...` | Change the initial placeholder for your text editor                                                                                                                                                                                                |
-| `editorContentStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to add styles to the editor content container. Useful if you want to limit the editor's height.                                                                                                                          |
-| `editorContentClassName`  | `string`                                                           | `undefined`                | The same idea of `editorContentStyle` but with classes.                                                                                                                                                                                            |
-| `mainContainerStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to style the main editor container                                                                                                                                                                                       |
-| `mainContainerClassName`  | `string`                                                           | `undefined`                | The same idea of `mainContainerStyle` but with classes.                                                                                                                                                                                            |
-| `onKeyDown`               | `KeyboardEventHandler`                                             | `undefined`                | A callback function that is triggered when a key is pressed within the editor. This allows you to handle custom keyboard shortcuts. For example, you can use this prop to implement a "send message" functionality when `Ctrl + Enter` is pressed. |
-| `enableTableOfContents`   | `boolean`                                                          | `false`                    | Experimental. Enables the app-owned document outline API for heading nodes.                                                                                                                                                                        |
-| `onTableOfContentsChange` | `(items: ScribeTableOfContentsItem[], isCreate?: boolean) => void` | `undefined`                | Experimental. Receives outline items whenever heading text, structure, or active/scrolled state changes.                                                                                                                                           |
+| Prop                      | Type                                                               | Default                    | Description                                                                                                                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`                 | `string`                                                           | `undefined`                | The initial content of the editor. Controlled updates through this prop are deprecated; prefer `ScribeRef.setContent` for programmatic updates after mount.                                                                                              |
+| `onContentChange`         | `(content: ScribeOnChangeContents) => void;`                       | `undefined`                | A callback function triggered whenever the editor's content changes. It receives an object containing the current content in various formats (`jsonContent`, `htmlContent`, `markdownContent`). Internal table-of-contents metadata updates are ignored. |
+| `editable`                | `boolean`                                                          | `true`                     | Controls whether the editor is editable.                                                                                                                                                                                                                 |
+| `autoFocus`               | `boolean`                                                          | `false`                    | Controls whether the editor should automatically focus when mounted.                                                                                                                                                                                     |
+| `extensions`              | `Extension[]`                                                      | `undefined`                | You can set your own extensions for the text editor. For more information, [check the tip tap extensions docs](https://tiptap.dev/docs/editor/core-concepts/extensions)                                                                                  |
+| `editorProps`             | `EditorProps`                                                      | `undefined`                | A tiptap-based prop to handle advanced use cases, you can read about it on their [documentation](https://tiptap.dev/docs/editor/api/editor#editorprops)                                                                                                  |
+| `showBarMenu`             | `boolean`                                                          | `true`                     | Determines whether to show the text editor top menu bar or not. This menu bar shows options to format the text                                                                                                                                           |
+| `placeholderText`         | `string`                                                           | `Type "/" for commands...` | Change the initial placeholder for your text editor                                                                                                                                                                                                      |
+| `editorContentStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to add styles to the editor content container. Useful if you want to limit the editor's height.                                                                                                                                |
+| `editorContentClassName`  | `string`                                                           | `undefined`                | The same idea of `editorContentStyle` but with classes.                                                                                                                                                                                                  |
+| `mainContainerStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to style the main editor container                                                                                                                                                                                             |
+| `mainContainerClassName`  | `string`                                                           | `undefined`                | The same idea of `mainContainerStyle` but with classes.                                                                                                                                                                                                  |
+| `onKeyDown`               | `KeyboardEventHandler`                                             | `undefined`                | A callback function that is triggered when a key is pressed within the editor. This allows you to handle custom keyboard shortcuts. For example, you can use this prop to implement a "send message" functionality when `Ctrl + Enter` is pressed.       |
+| `enableTableOfContents`   | `boolean`                                                          | `false`                    | Experimental. Enables the app-owned table-of-contents API for heading nodes.                                                                                                                                                                             |
+| `onTableOfContentsChange` | `(items: ScribeTableOfContentsItem[], isCreate?: boolean) => void` | `undefined`                | Experimental. Receives table-of-contents items whenever heading text, structure, or active/scrolled state changes.                                                                                                                                       |
 
 ## Helper Functions
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ A versatile, block-based rich text editor for diverse applications, built with T
 - **Markdown Paste:** Paste plain-text markdown into the editor and have it converted into rich content automatically.
 - **Versatile Integration:** Easily integrate `@clevertask/scribe` into any project requiring rich text editing.
 - **View and Edit:** Seamlessly switch between viewing and editing modes.
+- **Experimental Document Outline:** Subscribe to heading changes and render an app-owned outline outside the editor.
 
 ## Table of Contents
 
 - [@clevertask/scribe](#clevertaskscribe)
   - [Installation](#installation)
   - [Usage](#usage)
+  - [Experimental Document Outline](#experimental-document-outline)
   - [Math Expressions](#math-expressions)
   - [Props](#props)
   - [Helper Functions](#helper-functions)
@@ -40,7 +42,7 @@ npm install @clevertask/scribe
 import "@radix-ui/themes/styles.css";
 import "@clevertask/scribe/dist/main.css";
 import { Theme } from "@radix-ui/themes";
-import { Scribe, ScribeOnChangeContents } from "@clevertask/scribe";
+import { Scribe, ScribeRef } from "@clevertask/scribe";
 
 function App() {
   const onContentChange = useCallback(
@@ -101,6 +103,42 @@ function App() {
 }
 ```
 
+## Experimental Document Outline
+
+Scribe can expose a heading outline without rendering table-of-contents content inside the editable document. Enable the experimental API with `enableTableOfContents`, keep the latest items in your app state, and call `scrollToTableOfContentsItem` when a user selects an outline entry.
+
+```tsx
+import { Scribe, ScribeRef, ScribeTableOfContentsItem } from "@clevertask/scribe";
+import { useRef, useState } from "react";
+
+function DocumentEditor() {
+  const scribe = useRef<ScribeRef>(null);
+  const [outlineItems, setOutlineItems] = useState<ScribeTableOfContentsItem[]>([]);
+
+  return (
+    <>
+      <Scribe ref={scribe} enableTableOfContents onTableOfContentsChange={setOutlineItems} />
+
+      {outlineItems.length > 0 ? (
+        <nav aria-label="Document outline">
+          {outlineItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => scribe.current?.scrollToTableOfContentsItem(item)}
+            >
+              {item.textContent}
+            </button>
+          ))}
+        </nav>
+      ) : null}
+    </>
+  );
+}
+```
+
+The outline currently tracks default TipTap heading nodes only. Each item includes the heading text, depth, document position, DOM node, and active/scrolled state. This API is marked experimental while we validate the contract in real document surfaces.
+
 ## Math Expressions
 
 Scribe's default UI is styled with Radix Themes components. Load `@radix-ui/themes/styles.css` once in your app alongside `@clevertask/scribe/dist/main.css`, and render Scribe somewhere inside a Radix `<Theme>`.
@@ -134,21 +172,23 @@ If your content arrives as HTML (for example from a server), use the helper belo
 
 ## Props
 
-| Prop                     | Type                                         | Default                    | Description                                                                                                                                                                                                                                        |
-| ------------------------ | -------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`                | `string`                                     | `undefined`                | The initial content of the editor. This prop can also be used to control the editor's content. When `content` is updated, the editor's content will be updated accordingly.                                                                        |
-| `onContentChange`        | `(content: ScribeOnChangeContents) => void;` | `undefined`                | A callback function triggered whenever the editor's content changes. It receives an object containing the current content in various formats (`jsonContent`, `htmlContent`, `markdownContent`).                                                    |
-| `editable`               | `boolean`                                    | `true`                     | Controls whether the editor is editable.                                                                                                                                                                                                           |
-| `autoFocus`              | `boolean`                                    | `false`                    | Controls whether the editor should automatically focus when mounted.                                                                                                                                                                               |
-| `extensions`             | `Extension[]`                                | `undefined`                | You can set your own extensions for the text editor. For more information, [check the tip tap extensions docs](https://tiptap.dev/docs/editor/core-concepts/extensions)                                                                            |
-| `editorProps`            | `EditorProps`                                | `undefined`                | A tiptap-based prop to handle advanced use cases, you can read about it on their [documentation](https://tiptap.dev/docs/editor/api/editor#editorprops)                                                                                            |
-| `showBarMenu`            | `boolean`                                    | `true`                     | Determines whether to show the text editor top menu bar or not. This menu bar shows options to format the text                                                                                                                                     |
-| `placeholderText`        | `string`                                     | `Type "/" for commands...` | Change the initial placeholder for your text editor                                                                                                                                                                                                |
-| `editorContentStyle`     | `React.CSSProperties`                        | `undefined`                | You can send a CSS object to add styles to the editor content container. Useful if you want to limit the editor's height.                                                                                                                          |
-| `editorContentClassName` | `string`                                     | `undefined`                | The same idea of `editorContentStyle` but with classes.                                                                                                                                                                                            |
-| `mainContainerStyle`     | `React.CSSProperties`                        | `undefined`                | You can send a CSS object to style the main editor container                                                                                                                                                                                       |
-| `mainContainerClassName` | `string`                                     | `undefined`                | The same idea of `mainContainerStyle` but with classes.                                                                                                                                                                                            |
-| `onKeyDown`              | `KeyboardEventHandler`                       | `undefined`                | A callback function that is triggered when a key is pressed within the editor. This allows you to handle custom keyboard shortcuts. For example, you can use this prop to implement a "send message" functionality when `Ctrl + Enter` is pressed. |
+| Prop                      | Type                                                               | Default                    | Description                                                                                                                                                                                                                                        |
+| ------------------------- | ------------------------------------------------------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`                 | `string`                                                           | `undefined`                | The initial content of the editor. Controlled updates through this prop are deprecated; prefer `ScribeRef.setContent` for programmatic updates after mount.                                                                                        |
+| `onContentChange`         | `(content: ScribeOnChangeContents) => void;`                       | `undefined`                | A callback function triggered whenever the editor's content changes. It receives an object containing the current content in various formats (`jsonContent`, `htmlContent`, `markdownContent`). Internal outline metadata updates are ignored.     |
+| `editable`                | `boolean`                                                          | `true`                     | Controls whether the editor is editable.                                                                                                                                                                                                           |
+| `autoFocus`               | `boolean`                                                          | `false`                    | Controls whether the editor should automatically focus when mounted.                                                                                                                                                                               |
+| `extensions`              | `Extension[]`                                                      | `undefined`                | You can set your own extensions for the text editor. For more information, [check the tip tap extensions docs](https://tiptap.dev/docs/editor/core-concepts/extensions)                                                                            |
+| `editorProps`             | `EditorProps`                                                      | `undefined`                | A tiptap-based prop to handle advanced use cases, you can read about it on their [documentation](https://tiptap.dev/docs/editor/api/editor#editorprops)                                                                                            |
+| `showBarMenu`             | `boolean`                                                          | `true`                     | Determines whether to show the text editor top menu bar or not. This menu bar shows options to format the text                                                                                                                                     |
+| `placeholderText`         | `string`                                                           | `Type "/" for commands...` | Change the initial placeholder for your text editor                                                                                                                                                                                                |
+| `editorContentStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to add styles to the editor content container. Useful if you want to limit the editor's height.                                                                                                                          |
+| `editorContentClassName`  | `string`                                                           | `undefined`                | The same idea of `editorContentStyle` but with classes.                                                                                                                                                                                            |
+| `mainContainerStyle`      | `React.CSSProperties`                                              | `undefined`                | You can send a CSS object to style the main editor container                                                                                                                                                                                       |
+| `mainContainerClassName`  | `string`                                                           | `undefined`                | The same idea of `mainContainerStyle` but with classes.                                                                                                                                                                                            |
+| `onKeyDown`               | `KeyboardEventHandler`                                             | `undefined`                | A callback function that is triggered when a key is pressed within the editor. This allows you to handle custom keyboard shortcuts. For example, you can use this prop to implement a "send message" functionality when `Ctrl + Enter` is pressed. |
+| `enableTableOfContents`   | `boolean`                                                          | `false`                    | Experimental. Enables the app-owned document outline API for heading nodes.                                                                                                                                                                        |
+| `onTableOfContentsChange` | `(items: ScribeTableOfContentsItem[], isCreate?: boolean) => void` | `undefined`                | Experimental. Receives outline items whenever heading text, structure, or active/scrolled state changes.                                                                                                                                           |
 
 ## Helper Functions
 

--- a/lib/components/Scribe/extension/index.ts
+++ b/lib/components/Scribe/extension/index.ts
@@ -1,4 +1,4 @@
-import { ScribeProps } from "..";
+import type { ScribeProps } from "..";
 import Link from "./extension-link";
 import MarkdownPaste from "./extension-markdown-paste";
 import Focus from "@tiptap/extension-focus";
@@ -17,6 +17,7 @@ import { Mathematics } from "@tiptap/extension-mathematics";
 import Typography from "@tiptap/extension-typography";
 import Emoji, { gitHubEmojis } from "@tiptap/extension-emoji";
 import suggestion from "./emoji/suggest";
+import { ScribeTableOfContents } from "./tableOfContents";
 
 export const initExtensions = (props: ScribeProps) => [
   StarterKit.configure({
@@ -78,4 +79,11 @@ export const initExtensions = (props: ScribeProps) => [
   }),
   Mathematics,
   Typography,
+  ...(props.enableTableOfContents
+    ? [
+        ScribeTableOfContents.configure({
+          onUpdate: props.onTableOfContentsChange,
+        }),
+      ]
+    : []),
 ];

--- a/lib/components/Scribe/extension/tableOfContents.ts
+++ b/lib/components/Scribe/extension/tableOfContents.ts
@@ -1,0 +1,464 @@
+import { Editor, Extension } from "@tiptap/core";
+import { Node as TiptapNode } from "@tiptap/pm/model";
+import { EditorState, Plugin, PluginKey, Transaction } from "@tiptap/pm/state";
+
+export const SCRIBE_TABLE_OF_CONTENTS_META = "scribeTableOfContents";
+
+type ScrollParent = HTMLElement | Window;
+
+type HeadingEntry = {
+  node: TiptapNode;
+  pos: number;
+};
+
+export type ScribeTableOfContentsItem = {
+  dom: HTMLElement;
+  editor: Editor;
+  id: string;
+  isActive: boolean;
+  isScrolledOver: boolean;
+  itemIndex: number;
+  level: number;
+  node: TiptapNode;
+  originalLevel: number;
+  pos: number;
+  textContent: string;
+};
+
+export type ScribeTableOfContentsChangeHandler = (
+  items: ScribeTableOfContentsItem[],
+  isCreate?: boolean,
+) => void;
+
+export type ScribeTableOfContentsScrollTarget = ScribeTableOfContentsItem | string;
+
+type ScribeTableOfContentsOptions = {
+  anchorTypes: string[];
+  onUpdate?: ScribeTableOfContentsChangeHandler;
+};
+
+type ScribeTableOfContentsStorage = {
+  anchors: HTMLElement[];
+  content: ScribeTableOfContentsItem[];
+  hasCreated: boolean;
+  lastSignature: string;
+  rafId: number | null;
+  refresh: () => void;
+  scheduleRefresh: () => void;
+  scrollHandler: () => void;
+  scrollParent: ScrollParent | null;
+  updateScrollParent: () => void;
+};
+
+const pluginKey = new PluginKey("scribeTableOfContents");
+
+const slugify = (content: string) => {
+  const slug = content
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "heading";
+};
+
+const getHeadingLevel = (headline: HeadingEntry, previousItems: ScribeTableOfContentsItem[]) => {
+  const previousHeadline = previousItems[previousItems.length - 1];
+  const highestHeadlineAbove = [...previousItems]
+    .reverse()
+    .find((heading) => heading.originalLevel <= headline.node.attrs.level);
+  const highestLevelAbove = highestHeadlineAbove?.level || 1;
+
+  if (headline.node.attrs.level > (previousHeadline?.originalLevel || 1)) {
+    return (previousHeadline?.level || 1) + 1;
+  }
+
+  if (headline.node.attrs.level < (previousHeadline?.originalLevel || 1)) {
+    return highestLevelAbove;
+  }
+
+  return previousHeadline?.level || 1;
+};
+
+const getItemIndex = (previousItems: ScribeTableOfContentsItem[]) => {
+  const previousHeadline = previousItems[previousItems.length - 1];
+
+  return (previousHeadline?.itemIndex || 0) + 1;
+};
+
+const getHeadingId = (
+  node: TiptapNode,
+  usedIds: Map<string, number>,
+  existingId?: string | null,
+) => {
+  if (node.textContent.length === 0) {
+    return null;
+  }
+
+  const baseId = slugify(node.textContent);
+  const nextCount = (usedIds.get(baseId) || 0) + 1;
+  const id = nextCount === 1 ? baseId : `${baseId}-${nextCount}`;
+
+  usedIds.set(baseId, nextCount);
+
+  return existingId === id ? existingId : id;
+};
+
+const createTableOfContentsIdTransaction = (
+  state: EditorState,
+  anchorTypes: string[],
+): Transaction | null => {
+  const tr = state.tr;
+  const usedIds = new Map<string, number>();
+  let modified = false;
+
+  state.doc.descendants((node, pos) => {
+    if (!anchorTypes.includes(node.type.name)) {
+      return;
+    }
+
+    const currentId = node.attrs["data-toc-id"] as string | null | undefined;
+    const nextId = getHeadingId(node, usedIds, currentId);
+
+    if (currentId === nextId) {
+      return;
+    }
+
+    tr.setNodeMarkup(pos, undefined, {
+      ...node.attrs,
+      "data-toc-id": nextId,
+    });
+    modified = true;
+  });
+
+  if (!modified) {
+    return null;
+  }
+
+  return tr.setMeta(SCRIBE_TABLE_OF_CONTENTS_META, true).setMeta("addToHistory", false);
+};
+
+const isScrollable = (element: HTMLElement) => {
+  const { overflowY } = window.getComputedStyle(element);
+
+  return /(auto|scroll|overlay)/.test(overflowY) && element.scrollHeight > element.clientHeight;
+};
+
+const getScrollParent = (element: HTMLElement): ScrollParent => {
+  let parent = element.parentElement;
+
+  while (parent) {
+    if (isScrollable(parent)) {
+      return parent;
+    }
+
+    parent = parent.parentElement;
+  }
+
+  return window;
+};
+
+const isWindowScrollParent = (scrollParent: ScrollParent): scrollParent is Window => {
+  return typeof Window !== "undefined" && scrollParent instanceof Window;
+};
+
+const getActivationThreshold = (scrollParent: ScrollParent) => {
+  if (isWindowScrollParent(scrollParent)) {
+    return 32;
+  }
+
+  return scrollParent.getBoundingClientRect().top + 32;
+};
+
+const getHeadingElement = (editor: Editor, pos: number) => {
+  const dom = editor.view.nodeDOM(pos);
+
+  return dom instanceof HTMLElement ? dom : null;
+};
+
+const collectHeadingEntries = (editor: Editor, anchorTypes: string[]) => {
+  const entries: HeadingEntry[] = [];
+
+  editor.state.doc.descendants((node, pos) => {
+    if (!anchorTypes.includes(node.type.name) || node.textContent.length === 0) {
+      return;
+    }
+
+    entries.push({ node, pos });
+  });
+
+  return entries;
+};
+
+const withActiveStates = (
+  items: ScribeTableOfContentsItem[],
+  scrollParent: ScrollParent | null,
+) => {
+  if (!scrollParent) {
+    return items;
+  }
+
+  const threshold = getActivationThreshold(scrollParent);
+  const scrolledOverIds = new Set<string>();
+  let activeId: string | null = null;
+
+  items.forEach((item) => {
+    if (item.dom.getBoundingClientRect().top <= threshold) {
+      activeId = item.id;
+      scrolledOverIds.add(item.id);
+    }
+  });
+
+  return items.map((item) => ({
+    ...item,
+    isActive: item.id === activeId,
+    isScrolledOver: scrolledOverIds.has(item.id),
+  }));
+};
+
+const buildTableOfContentsItems = (
+  editor: Editor,
+  anchorTypes: string[],
+  scrollParent: ScrollParent | null,
+) => {
+  const entries = collectHeadingEntries(editor, anchorTypes);
+  const items: ScribeTableOfContentsItem[] = [];
+
+  entries.forEach((entry) => {
+    const id = entry.node.attrs["data-toc-id"] as string | null | undefined;
+    const dom = getHeadingElement(editor, entry.pos);
+
+    if (!id || !dom) {
+      return;
+    }
+
+    const originalLevel = Number(entry.node.attrs.level) || 1;
+    const level = getHeadingLevel(entry, items);
+    const itemIndex = getItemIndex(items);
+
+    items.push({
+      dom,
+      editor,
+      id,
+      isActive: false,
+      isScrolledOver: false,
+      itemIndex,
+      level,
+      node: entry.node,
+      originalLevel,
+      pos: entry.pos,
+      textContent: entry.node.textContent,
+    });
+  });
+
+  return withActiveStates(items, scrollParent);
+};
+
+const getTableOfContentsSignature = (items: ScribeTableOfContentsItem[]) => {
+  return JSON.stringify(
+    items.map((item) => ({
+      id: item.id,
+      isActive: item.isActive,
+      isScrolledOver: item.isScrolledOver,
+      itemIndex: item.itemIndex,
+      level: item.level,
+      originalLevel: item.originalLevel,
+      pos: item.pos,
+      textContent: item.textContent,
+    })),
+  );
+};
+
+const emitTableOfContentsUpdate = (
+  storage: ScribeTableOfContentsStorage,
+  options: ScribeTableOfContentsOptions,
+  items: ScribeTableOfContentsItem[],
+) => {
+  const signature = getTableOfContentsSignature(items);
+  const isCreate = !storage.hasCreated;
+
+  storage.anchors = items.map((item) => item.dom);
+  storage.content = items;
+
+  if (!isCreate && signature === storage.lastSignature) {
+    return;
+  }
+
+  storage.hasCreated = true;
+  storage.lastSignature = signature;
+  options.onUpdate?.(items, isCreate);
+};
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    scribeTableOfContents: {
+      updateScribeTableOfContents: () => ReturnType;
+    };
+  }
+
+  interface Storage {
+    scribeTableOfContents: ScribeTableOfContentsStorage;
+  }
+}
+
+export const ScribeTableOfContents = Extension.create<
+  ScribeTableOfContentsOptions,
+  ScribeTableOfContentsStorage
+>({
+  name: "scribeTableOfContents",
+
+  addOptions() {
+    return {
+      anchorTypes: ["heading"],
+    };
+  },
+
+  addStorage() {
+    return {
+      anchors: [],
+      content: [],
+      hasCreated: false,
+      lastSignature: "",
+      rafId: null,
+      refresh: () => null,
+      scheduleRefresh: () => null,
+      scrollHandler: () => null,
+      scrollParent: null,
+      updateScrollParent: () => null,
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.anchorTypes,
+        attributes: {
+          "data-toc-id": {
+            default: null,
+            renderHTML: (attributes) => {
+              const id = attributes["data-toc-id"];
+
+              return id ? { "data-toc-id": id } : {};
+            },
+            parseHTML: (element) => element.getAttribute("data-toc-id"),
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      updateScribeTableOfContents:
+        () =>
+        ({ dispatch }) => {
+          if (dispatch) {
+            this.storage.refresh();
+          }
+
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: pluginKey,
+
+        appendTransaction: (transactions, _oldState, newState) => {
+          if (typeof window === "undefined") {
+            return null;
+          }
+
+          const shouldSkip = transactions.some(
+            (transaction) =>
+              transaction.getMeta(SCRIBE_TABLE_OF_CONTENTS_META) ||
+              transaction.getMeta("composition"),
+          );
+
+          if (shouldSkip || !transactions.some((transaction) => transaction.docChanged)) {
+            return null;
+          }
+
+          return createTableOfContentsIdTransaction(newState, this.options.anchorTypes);
+        },
+      }),
+    ];
+  },
+
+  onCreate() {
+    if (typeof window === "undefined" || !this.editor.view) {
+      return;
+    }
+
+    this.storage.scrollHandler = () => {
+      this.storage.refresh();
+    };
+
+    this.storage.updateScrollParent = () => {
+      const nextScrollParent = getScrollParent(this.editor.view.dom);
+
+      if (this.storage.scrollParent === nextScrollParent) {
+        return;
+      }
+
+      this.storage.scrollParent?.removeEventListener("scroll", this.storage.scrollHandler);
+      this.storage.scrollParent = nextScrollParent;
+      this.storage.scrollParent.addEventListener("scroll", this.storage.scrollHandler);
+    };
+
+    this.storage.refresh = () => {
+      if (this.editor.isDestroyed) {
+        return;
+      }
+
+      this.storage.updateScrollParent();
+      const items = buildTableOfContentsItems(
+        this.editor,
+        this.options.anchorTypes,
+        this.storage.scrollParent,
+      );
+
+      emitTableOfContentsUpdate(this.storage, this.options, items);
+    };
+
+    this.storage.scheduleRefresh = () => {
+      if (this.storage.rafId !== null) {
+        window.cancelAnimationFrame(this.storage.rafId);
+      }
+
+      this.storage.rafId = window.requestAnimationFrame(() => {
+        this.storage.rafId = null;
+        this.storage.refresh();
+      });
+    };
+
+    const initialTransaction = createTableOfContentsIdTransaction(
+      this.editor.state,
+      this.options.anchorTypes,
+    );
+
+    if (initialTransaction) {
+      this.editor.view.dispatch(initialTransaction);
+    }
+
+    this.storage.scheduleRefresh();
+  },
+
+  onTransaction({ transaction }) {
+    if (transaction.docChanged) {
+      this.storage.scheduleRefresh();
+    }
+  },
+
+  onDestroy() {
+    if (typeof window !== "undefined" && this.storage.rafId !== null) {
+      window.cancelAnimationFrame(this.storage.rafId);
+    }
+
+    this.storage.scrollParent?.removeEventListener("scroll", this.storage.scrollHandler);
+  },
+});

--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -46,7 +46,7 @@ export interface ScribeRef {
   resetContent: () => void;
   getContent: (contentType: "html" | "json" | "markdown") => string | JSONContent | undefined;
   setContent: (content: Content) => void;
-  /** @experimental The table of contents API may change while we stabilize outline behavior. */
+  /** @experimental The table of contents API may change while we stabilize this behavior. */
   scrollToTableOfContentsItem: (target: ScribeTableOfContentsScrollTarget) => void;
   editor: Editor;
 }
@@ -71,9 +71,9 @@ export interface ScribeProps {
   mainContainerClassName?: ClassValue;
   onKeyDown?: KeyboardEventHandler;
   mobile?: boolean;
-  /** @experimental Enables Scribe's app-owned document outline API. */
+  /** @experimental Enables Scribe's app-owned table-of-contents API. */
   enableTableOfContents?: boolean;
-  /** @experimental Receives the current heading outline when it changes. */
+  /** @experimental Receives the current table-of-contents items when they change. */
   onTableOfContentsChange?: ScribeTableOfContentsChangeHandler;
 }
 
@@ -95,7 +95,13 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
     mobile,
     onTableOfContentsChange,
   } = props;
+
+  // Initial content is passed into the editor constructor, so the deprecated
+  // content sync effect skips its first run to avoid re-applying the same doc.
   const didSetInitialContentInEditorOptionsRef = useRef(!externalEditor && content !== undefined);
+
+  // The TipTap editor/extensions live outside React's render cycle. These refs
+  // keep the latest table-of-contents items and callback available to imperative editor APIs.
   const tableOfContentsItemsRef = useRef<ScribeTableOfContentsItem[]>([]);
   const onTableOfContentsChangeRef = useRef(onTableOfContentsChange);
 

--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -3,6 +3,12 @@ import BarMenu from "../Menu/BarMenu";
 import { ClassValue, clsx } from "clsx";
 import { html2md } from "../../utils";
 import { initExtensions } from "./extension";
+import { SCRIBE_TABLE_OF_CONTENTS_META } from "./extension/tableOfContents";
+import type {
+  ScribeTableOfContentsChangeHandler,
+  ScribeTableOfContentsItem,
+  ScribeTableOfContentsScrollTarget,
+} from "./extension/tableOfContents";
 import {
   Content,
   Editor,
@@ -18,9 +24,16 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from "react";
 import { ListOptionBar } from "../Menu/Mobile/ListOptionBar";
+
+export type {
+  ScribeTableOfContentsChangeHandler,
+  ScribeTableOfContentsItem,
+  ScribeTableOfContentsScrollTarget,
+} from "./extension/tableOfContents";
 
 export type ScribeOnChangeContents = {
   jsonContent: Content;
@@ -33,11 +46,17 @@ export interface ScribeRef {
   resetContent: () => void;
   getContent: (contentType: "html" | "json" | "markdown") => string | JSONContent | undefined;
   setContent: (content: Content) => void;
+  /** @experimental The table of contents API may change while we stabilize outline behavior. */
+  scrollToTableOfContentsItem: (target: ScribeTableOfContentsScrollTarget) => void;
   editor: Editor;
 }
 
 export interface ScribeProps {
   onContentChange?: (content: ScribeOnChangeContents) => void;
+  /**
+   * @deprecated Controlled content updates are being phased out. Prefer
+   * `ScribeRef.setContent` for programmatic updates after mount.
+   */
   content?: string;
   editable?: boolean;
   autoFocus?: boolean;
@@ -52,6 +71,10 @@ export interface ScribeProps {
   mainContainerClassName?: ClassValue;
   onKeyDown?: KeyboardEventHandler;
   mobile?: boolean;
+  /** @experimental Enables Scribe's app-owned document outline API. */
+  enableTableOfContents?: boolean;
+  /** @experimental Receives the current heading outline when it changes. */
+  onTableOfContentsChange?: ScribeTableOfContentsChangeHandler;
 }
 
 export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
@@ -70,10 +93,30 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
     onKeyDown,
     externalEditor,
     mobile,
+    onTableOfContentsChange,
   } = props;
+  const didSetInitialContentInEditorOptionsRef = useRef(!externalEditor && content !== undefined);
+  const tableOfContentsItemsRef = useRef<ScribeTableOfContentsItem[]>([]);
+  const onTableOfContentsChangeRef = useRef(onTableOfContentsChange);
+
+  useEffect(() => {
+    onTableOfContentsChangeRef.current = onTableOfContentsChange;
+  }, [onTableOfContentsChange]);
+
+  const handleTableOfContentsChange = useCallback(
+    (items: ScribeTableOfContentsItem[], isCreate?: boolean) => {
+      tableOfContentsItemsRef.current = items;
+      onTableOfContentsChangeRef.current?.(items, isCreate);
+    },
+    [],
+  );
 
   const onUpdate = useCallback(
-    ({ editor }: EditorEvents["update"]) => {
+    ({ editor, transaction }: EditorEvents["update"]) => {
+      if (transaction.getMeta(SCRIBE_TABLE_OF_CONTENTS_META)) {
+        return;
+      }
+
       const htmlContent = editor.getHTML();
       const jsonContent = editor.getJSON();
       const isProgrammatic = !editable;
@@ -94,8 +137,15 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
       externalEditor ??
       new Editor({
         ...editorProps,
+        content: content ?? editorProps?.content,
         editable,
-        extensions: [...initExtensions(props), ...(extensions ?? [])],
+        extensions: [
+          ...initExtensions({
+            ...props,
+            onTableOfContentsChange: handleTableOfContentsChange,
+          }),
+          ...(extensions ?? []),
+        ],
         editorProps: {
           attributes: {
             class: "scribe",
@@ -129,17 +179,55 @@ export const Scribe = forwardRef<ScribeRef, ScribeProps>((props, ref) => {
     [editor],
   );
 
+  const scrollToTableOfContentsItem = useCallback(
+    (target: ScribeTableOfContentsScrollTarget) => {
+      const targetId = typeof target === "string" ? target : target.id;
+      const item =
+        tableOfContentsItemsRef.current.find((currentItem) => currentItem.id === targetId) ??
+        (typeof target === "string" ? undefined : target);
+
+      if (!item || editor.isDestroyed) {
+        return;
+      }
+
+      const dom = editor.view.nodeDOM(item.pos);
+      const headingElement = dom instanceof HTMLElement ? dom : item.dom;
+
+      if (editor.isEditable) {
+        const headingEndPosition = Math.max(
+          0,
+          Math.min(item.pos + item.node.nodeSize - 1, editor.state.doc.content.size),
+        );
+
+        editor.commands.focus(headingEndPosition, { scrollIntoView: false });
+      }
+
+      headingElement.scrollIntoView({ behavior: "smooth", block: "start" });
+    },
+    [editor],
+  );
+
   useImperativeHandle(ref, () => {
     return {
       resetContent,
       setContent,
       getContent,
+      scrollToTableOfContentsItem,
       editor,
     };
-  }, [editor, getContent, resetContent, setContent]);
+  }, [editor, getContent, resetContent, scrollToTableOfContentsItem, setContent]);
 
   useEffect(() => {
-    editor.commands.setContent(content || "");
+    if (content === undefined) {
+      return;
+    }
+
+    if (didSetInitialContentInEditorOptionsRef.current) {
+      didSetInitialContentInEditorOptionsRef.current = false;
+      return;
+    }
+
+    editor.commands.setContent(content, { emitUpdate: false });
   }, [content, editor]);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,103 @@
 import "@radix-ui/themes/styles.css";
 import "../lib/styles/main.css";
 import { Theme } from "@radix-ui/themes";
-import { useRef } from "react";
-import { Scribe, ScribeRef } from "../lib/main";
+import { useRef, useState } from "react";
+import { Scribe, ScribeRef, ScribeTableOfContentsItem } from "../lib/main";
+
+const demoContent = `
+  <h1>Math fundamentals</h1>
+  <p>Start with a short note about the document.</p>
+  <h2>Linear equations</h2>
+  <p>Keep related examples close to the heading.</p>
+  <h2>Quadratic equations</h2>
+  <p>Practice steps can live under each section.</p>
+  <h3>Factoring</h3>
+  <p>A smaller section still appears nested in the outline.</p>
+`;
 
 const ChatBox = function ChatBox() {
   const editor = useRef<ScribeRef>(null);
+  const [outlineItems, setOutlineItems] = useState<ScribeTableOfContentsItem[]>([]);
+  const [outlineOpen, setOutlineOpen] = useState(false);
+
   return (
-    <>
+    <div style={{ position: "relative" }}>
       <Scribe
         ref={editor}
+        content={demoContent}
+        enableTableOfContents
         onContentChange={(c) => console.log(c)}
+        onTableOfContentsChange={(items) => setOutlineItems(items)}
         placeholderText="Type your message..."
         editorContentStyle={{ maxHeight: "200px", overflowY: "scroll" }}
       />
-    </>
+
+      {outlineItems.length > 0 ? (
+        <div style={{ position: "absolute", right: "12px", top: "12px", zIndex: 1 }}>
+          <button
+            type="button"
+            onClick={() => setOutlineOpen((isOpen) => !isOpen)}
+            style={{
+              background: "var(--accent-9)",
+              border: 0,
+              borderRadius: "8px",
+              color: "white",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontWeight: 600,
+              padding: "6px 10px",
+            }}
+          >
+            Outline
+          </button>
+
+          {outlineOpen ? (
+            <div
+              style={{
+                background: "var(--color-panel-solid)",
+                border: "1px solid var(--gray-6)",
+                borderRadius: "8px",
+                boxShadow: "0 16px 32px -24px rgba(15, 23, 42, 0.55)",
+                marginTop: "6px",
+                maxWidth: "240px",
+                minWidth: "200px",
+                padding: "6px",
+              }}
+            >
+              {outlineItems.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => {
+                    editor.current?.scrollToTableOfContentsItem(item);
+                    setOutlineOpen(false);
+                  }}
+                  style={{
+                    background: item.isActive ? "var(--accent-a3)" : "transparent",
+                    border: 0,
+                    borderRadius: "6px",
+                    color: "var(--gray-12)",
+                    cursor: "pointer",
+                    display: "block",
+                    fontSize: "13px",
+                    fontWeight: item.isActive ? 600 : 400,
+                    overflow: "hidden",
+                    padding: "7px 8px",
+                    paddingLeft: `${8 + (item.level - 1) * 12}px`,
+                    textAlign: "left",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    width: "100%",
+                  }}
+                >
+                  {item.textContent}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,13 @@ const demoContent = `
   <h2>Quadratic equations</h2>
   <p>Practice steps can live under each section.</p>
   <h3>Factoring</h3>
-  <p>A smaller section still appears nested in the outline.</p>
+  <p>A smaller section still appears nested in the table of contents.</p>
 `;
 
 const ChatBox = function ChatBox() {
   const editor = useRef<ScribeRef>(null);
-  const [outlineItems, setOutlineItems] = useState<ScribeTableOfContentsItem[]>([]);
-  const [outlineOpen, setOutlineOpen] = useState(false);
+  const [tableOfContentsItems, setTableOfContentsItems] = useState<ScribeTableOfContentsItem[]>([]);
+  const [tableOfContentsOpen, setTableOfContentsOpen] = useState(false);
 
   return (
     <div style={{ position: "relative" }}>
@@ -27,16 +27,16 @@ const ChatBox = function ChatBox() {
         content={demoContent}
         enableTableOfContents
         onContentChange={(c) => console.log(c)}
-        onTableOfContentsChange={(items) => setOutlineItems(items)}
+        onTableOfContentsChange={(items) => setTableOfContentsItems(items)}
         placeholderText="Type your message..."
         editorContentStyle={{ maxHeight: "200px", overflowY: "scroll" }}
       />
 
-      {outlineItems.length > 0 ? (
+      {tableOfContentsItems.length > 0 ? (
         <div style={{ position: "absolute", right: "12px", top: "12px", zIndex: 1 }}>
           <button
             type="button"
-            onClick={() => setOutlineOpen((isOpen) => !isOpen)}
+            onClick={() => setTableOfContentsOpen((isOpen) => !isOpen)}
             style={{
               background: "var(--accent-9)",
               border: 0,
@@ -51,7 +51,7 @@ const ChatBox = function ChatBox() {
             Outline
           </button>
 
-          {outlineOpen ? (
+          {tableOfContentsOpen ? (
             <div
               style={{
                 background: "var(--color-panel-solid)",
@@ -64,13 +64,13 @@ const ChatBox = function ChatBox() {
                 padding: "6px",
               }}
             >
-              {outlineItems.map((item) => (
+              {tableOfContentsItems.map((item) => (
                 <button
                   key={item.id}
                   type="button"
                   onClick={() => {
                     editor.current?.scrollToTableOfContentsItem(item);
-                    setOutlineOpen(false);
+                    setTableOfContentsOpen(false);
                   }}
                   style={{
                     background: item.isActive ? "var(--accent-a3)" : "transparent",


### PR DESCRIPTION
## Why

Long documents need a lightweight way to jump between headings without inserting a table-of-contents block into the editable document. We tried the [TipTap ToC package](https://tiptap.dev/docs/editor/extensions/functionality/table-of-contents) first, but its generated IDs and scroll-driven updates made Scribe table-of-contents state difficult to reason about.

This adds an experimental Scribe-owned table-of-contents API so consumers can render their own UI.