### PR TITLE
fix(toc): avoid marking headings active before layout settles

### DIFF
--- a/lib/components/Scribe/extension/tableOfContents.ts
+++ b/lib/components/Scribe/extension/tableOfContents.ts
@@ -42,6 +42,7 @@ type ScribeTableOfContentsStorage = {
   content: ScribeTableOfContentsItem[];
   hasCreated: boolean;
   lastSignature: string;
+  layoutRefreshRetries: number;
   rafId: number | null;
   refresh: () => void;
   scheduleRefresh: () => void;
@@ -51,6 +52,7 @@ type ScribeTableOfContentsStorage = {
 };
 
 const pluginKey = new PluginKey("scribeTableOfContents");
+const MAX_LAYOUT_REFRESH_RETRIES = 10;
 
 const slugify = (content: string) => {
   const slug = content
@@ -172,6 +174,10 @@ const getActivationThreshold = (scrollParent: ScrollParent) => {
   return scrollParent.getBoundingClientRect().top + 32;
 };
 
+const isElementMeasurable = (element: HTMLElement) => {
+  return element.isConnected && element.getClientRects().length > 0;
+};
+
 const getHeadingElement = (editor: Editor, pos: number) => {
   const dom = editor.view.nodeDOM(pos);
 
@@ -192,11 +198,28 @@ const collectHeadingEntries = (editor: Editor, anchorTypes: string[]) => {
   return entries;
 };
 
+const canMeasureActiveStates = (
+  items: ScribeTableOfContentsItem[],
+  scrollParent: ScrollParent | null,
+) => {
+  // Tiptap can create the editor view before React mounts it into the page.
+  // Detached heading nodes measure as if every heading is at the top.
+  if (items.length === 0) {
+    return true;
+  }
+
+  if (!scrollParent || !items.every((item) => isElementMeasurable(item.dom))) {
+    return false;
+  }
+
+  return isWindowScrollParent(scrollParent) || isElementMeasurable(scrollParent);
+};
+
 const withActiveStates = (
   items: ScribeTableOfContentsItem[],
   scrollParent: ScrollParent | null,
 ) => {
-  if (!scrollParent) {
+  if (!canMeasureActiveStates(items, scrollParent)) {
     return items;
   }
 
@@ -321,6 +344,7 @@ export const ScribeTableOfContents = Extension.create<
       content: [],
       hasCreated: false,
       lastSignature: "",
+      layoutRefreshRetries: 0,
       rafId: null,
       refresh: () => null,
       scheduleRefresh: () => null,
@@ -421,8 +445,23 @@ export const ScribeTableOfContents = Extension.create<
         this.options.anchorTypes,
         this.storage.scrollParent,
       );
+      const canMeasureActiveItems =
+        this.editor.view.dom.isConnected &&
+        canMeasureActiveStates(items, this.storage.scrollParent);
+
+      if (canMeasureActiveItems) {
+        this.storage.layoutRefreshRetries = 0;
+      }
 
       emitTableOfContentsUpdate(this.storage, this.options, items);
+
+      if (
+        !canMeasureActiveItems &&
+        this.storage.layoutRefreshRetries < MAX_LAYOUT_REFRESH_RETRIES
+      ) {
+        this.storage.layoutRefreshRetries += 1;
+        this.storage.scheduleRefresh();
+      }
     };
 
     this.storage.scheduleRefresh = () => {


### PR DESCRIPTION
## Why

The Table of Contents could mark the last heading as active immediately after a page reload, even when the user was visually at the top of the document.

This made downstream UIs, like CleverTask’s floating Table of Contents, open scrolled to the wrong section. The issue came from Scribe computing active heading state before the editor heading DOM was fully mounted and measurable.

## Approach

- Guard active/scrolled state calculation until heading elements are connected and measurable.
- Keep emitting the ToC item list while layout is not ready, but without assigning a misleading active item.
- Retry the ToC refresh for a few animation frames so active state settles once the editor layout is real.

Relevant file:
https://github.com/clevertask/scribe/blob/chore/scribe-toc-active-state/lib/components/Scribe/extension/tableOfContents.ts