### PR TITLE
Make Scribe slash commands configurable for domain-specific editors

### DIFF
--- a/lib/components/Scribe/extension/index.ts
+++ b/lib/components/Scribe/extension/index.ts
@@ -12,78 +12,99 @@ import Highlight from "@tiptap/extension-highlight";
 import SelectedText from "./extension-selectedText";
 import renderItems from "./slashCommand/renderItems";
 import Placeholder from "@tiptap/extension-placeholder";
-import { getSuggestionItems } from "./slashCommand/items";
+import { getSlashCommandContext, getSuggestionItems } from "./slashCommand/items";
 import { Mathematics } from "@tiptap/extension-mathematics";
 import Typography from "@tiptap/extension-typography";
 import Emoji, { gitHubEmojis } from "@tiptap/extension-emoji";
 import suggestion from "./emoji/suggest";
 import { ScribeTableOfContents } from "./tableOfContents";
 
-export const initExtensions = (props: ScribeProps) => [
-  StarterKit.configure({
-    dropcursor: {
-      width: 4,
-      color: "#ebf6fe",
-    },
-  }),
-  TaskList.configure({
-    HTMLAttributes: {
-      class: "scribe-task-list",
-    },
-  }),
-  TaskItem.configure({
-    nested: true,
-  }),
-  TableKit.configure({
-    table: { resizable: true },
-  }),
-  Placeholder.configure({
-    showOnlyWhenEditable: true,
-    includeChildren: true,
-    showOnlyCurrent: false,
-    emptyEditorClass: "is-editor-empty",
-    emptyNodeClass: "is-node-empty",
-    placeholder: ({ editor: coreEditor, node }) => {
-      if (coreEditor.isDestroyed) {
-        return "";
-      }
-      if (node.type.name === "heading") {
-        return `Heading ${node.attrs.level}`;
-      }
+export const initExtensions = (props: ScribeProps) => {
+  const {
+    items: getCustomSlashCommandItems,
+    render: renderSlashCommandItems,
+    ...slashSuggestion
+  } = props.slashCommand ?? {};
 
-      return props.placeholderText || 'Type "/" for commands...';
-    },
-  }),
-  Focus.configure({ mode: "deepest", className: "has-focus" }),
-  MarkdownPaste,
-  SlashCommand.configure({
-    slashSuggestion: {
-      items: getSuggestionItems,
-      render: renderItems,
-    },
-  }),
-  Highlight,
-  SelectedText,
-  Link,
-  Image.configure({
-    inline: true,
-    HTMLAttributes: {
-      class: "scribe-image-node",
-    },
-    allowBase64: true,
-  }),
-  Emoji.configure({
-    emojis: gitHubEmojis,
-    enableEmoticons: true,
-    suggestion: suggestion(),
-  }),
-  Mathematics,
-  Typography,
-  ...(props.enableTableOfContents
-    ? [
-        ScribeTableOfContents.configure({
-          onUpdate: props.onTableOfContentsChange,
-        }),
-      ]
-    : []),
-];
+  return [
+    StarterKit.configure({
+      dropcursor: {
+        width: 4,
+        color: "#ebf6fe",
+      },
+    }),
+    TaskList.configure({
+      HTMLAttributes: {
+        class: "scribe-task-list",
+      },
+    }),
+    TaskItem.configure({
+      nested: true,
+    }),
+    TableKit.configure({
+      table: { resizable: true },
+    }),
+    Placeholder.configure({
+      showOnlyWhenEditable: true,
+      includeChildren: true,
+      showOnlyCurrent: false,
+      emptyEditorClass: "is-editor-empty",
+      emptyNodeClass: "is-node-empty",
+      placeholder: ({ editor: coreEditor, node }) => {
+        if (coreEditor.isDestroyed) {
+          return "";
+        }
+        if (node.type.name === "heading") {
+          return `Heading ${node.attrs.level}`;
+        }
+
+        return props.placeholderText || 'Type "/" for commands...';
+      },
+    }),
+    Focus.configure({ mode: "deepest", className: "has-focus" }),
+    MarkdownPaste,
+    SlashCommand.configure({
+      slashSuggestion: {
+        ...slashSuggestion,
+        items: (suggestionProps) => {
+          const defaultItems = getSuggestionItems(suggestionProps);
+
+          if (!getCustomSlashCommandItems) {
+            return defaultItems;
+          }
+
+          return getCustomSlashCommandItems({
+            ...suggestionProps,
+            context: getSlashCommandContext(suggestionProps.editor),
+            defaultItems,
+          });
+        },
+        render: renderSlashCommandItems ?? renderItems,
+      },
+    }),
+    Highlight,
+    SelectedText,
+    Link,
+    Image.configure({
+      inline: true,
+      HTMLAttributes: {
+        class: "scribe-image-node",
+      },
+      allowBase64: true,
+    }),
+    Emoji.configure({
+      emojis: gitHubEmojis,
+      enableEmoticons: true,
+      suggestion: suggestion(),
+    }),
+    Mathematics,
+    Typography,
+    ...(props.enableTableOfContents
+      ? [
+          ScribeTableOfContents.configure({
+            onUpdate: props.onTableOfContentsChange,
+          }),
+        ]
+      : []),
+  ];
+};

--- a/lib/components/Scribe/extension/slashCommand/index.ts
+++ b/lib/components/Scribe/extension/slashCommand/index.ts
@@ -1,10 +1,29 @@
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import Suggestion, { SuggestionOptions } from "@tiptap/suggestion";
+import type { SlashCommandItemsProvider, SuggestionItem } from "./items";
 
 export const slashMenuPluginKey = new PluginKey("slashSuggestion");
 
-export const SlashCommand = Extension.create({
+export type ScribeSlashCommandOptions = Omit<
+  Partial<SuggestionOptions<SuggestionItem, SuggestionItem>>,
+  "command" | "editor" | "items"
+> & {
+  items?: SlashCommandItemsProvider;
+};
+
+export type {
+  SlashCommandContext,
+  SlashCommandItemsProvider,
+  SlashCommandItemsProviderProps,
+  SuggestionItem,
+} from "./items";
+
+type SlashCommandOptions = {
+  slashSuggestion: Partial<SuggestionOptions<SuggestionItem, SuggestionItem>>;
+};
+
+export const SlashCommand = Extension.create<SlashCommandOptions>({
   name: "slashCommand",
 
   addOptions() {
@@ -16,7 +35,7 @@ export const SlashCommand = Extension.create({
         command: ({ editor, range, props }) => {
           props.command({ editor, range, props });
         },
-      } as Partial<SuggestionOptions>,
+      } as Partial<SuggestionOptions<SuggestionItem, SuggestionItem>>,
     };
   },
 

--- a/lib/components/Scribe/extension/slashCommand/items.tsx
+++ b/lib/components/Scribe/extension/slashCommand/items.tsx
@@ -9,7 +9,31 @@ export enum SuggestionItemType {
 interface CommandProps {
   editor: Editor;
   range: Range;
+  props: SuggestionItem;
 }
+
+export interface SlashCommandContext {
+  isInsideListItem: boolean;
+  isInsideBulletList: boolean;
+  isInsideOrderedList: boolean;
+  isInsideTaskList: boolean;
+  listDepth: number;
+  parentListType: string | null;
+  parentNodeType: string;
+  selectionFrom: number;
+  selectionTo: number;
+}
+
+export interface SlashCommandItemsProviderProps {
+  query: string;
+  editor: Editor;
+  context: SlashCommandContext;
+  defaultItems: SuggestionItem[];
+}
+
+export type SlashCommandItemsProvider = (
+  props: SlashCommandItemsProviderProps,
+) => SuggestionItem[] | Promise<SuggestionItem[]>;
 
 export interface SuggestionItem {
   title: string;
@@ -19,6 +43,37 @@ export interface SuggestionItem {
   icon?: ReactNode;
   command: (props: CommandProps) => void;
 }
+
+export const getSlashCommandContext = (editor: Editor): SlashCommandContext => {
+  const { from, to } = editor.state.selection;
+  const $from = editor.state.doc.resolve(from);
+  let listDepth = 0;
+  let parentListType: string | null = null;
+
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const nodeType = $from.node(depth).type.name;
+
+    if (nodeType === "listItem") {
+      listDepth += 1;
+    }
+
+    if (!parentListType && ["bulletList", "orderedList", "taskList"].includes(nodeType)) {
+      parentListType = nodeType;
+    }
+  }
+
+  return {
+    isInsideListItem: listDepth > 0,
+    isInsideBulletList: parentListType === "bulletList",
+    isInsideOrderedList: parentListType === "orderedList",
+    isInsideTaskList: parentListType === "taskList",
+    listDepth,
+    parentListType,
+    parentNodeType: $from.parent.type.name,
+    selectionFrom: from,
+    selectionTo: to,
+  };
+};
 
 export const getSuggestionItems = (props: { query: string; editor: Editor }) => {
   const { query } = props;

--- a/lib/components/Scribe/index.tsx
+++ b/lib/components/Scribe/index.tsx
@@ -3,6 +3,7 @@ import BarMenu from "../Menu/BarMenu";
 import { ClassValue, clsx } from "clsx";
 import { html2md } from "../../utils";
 import { initExtensions } from "./extension";
+import type { ScribeSlashCommandOptions } from "./extension/slashCommand";
 import { SCRIBE_TABLE_OF_CONTENTS_META } from "./extension/tableOfContents";
 import type {
   ScribeTableOfContentsChangeHandler,
@@ -29,6 +30,14 @@ import {
 } from "react";
 import { ListOptionBar } from "../Menu/Mobile/ListOptionBar";
 
+export type {
+  ScribeSlashCommandOptions,
+  SlashCommandContext,
+  SlashCommandItemsProvider,
+  SlashCommandItemsProviderProps,
+  SuggestionItem,
+} from "./extension/slashCommand";
+export { SuggestionItemType } from "./extension/slashCommand/items";
 export type {
   ScribeTableOfContentsChangeHandler,
   ScribeTableOfContentsItem,
@@ -71,6 +80,11 @@ export interface ScribeProps {
   mainContainerClassName?: ClassValue;
   onKeyDown?: KeyboardEventHandler;
   mobile?: boolean;
+  /**
+   * Allows callers to customize Scribe's slash command menu while keeping
+   * Scribe's default command list available.
+   */
+  slashCommand?: ScribeSlashCommandOptions;
   /** @experimental Enables Scribe's app-owned table-of-contents API. */
   enableTableOfContents?: boolean;
   /** @experimental Receives the current table-of-contents items when they change. */


### PR DESCRIPTION
## Why

CleverTask's bulk planner needs domain-specific slash commands, but Scribe should stay generic. Today the slash menu is wired to one built-in item list, which makes it hard for consumers to hide, replace, or append commands based on editor context.

This change gives Scribe callers a small extension point for slash commands while preserving the current default menu for existing editors.

## What changed

- Added a `slashCommand` prop to `Scribe` so consumers can configure Tiptap suggestion options.
- Added a custom slash item provider that receives:
  - the current query and editor
  - Scribe's filtered `defaultItems`
  - generic editor context such as list depth and whether the selection is inside bullet, ordered, or task lists
- Kept Scribe's default slash items and renderer as the fallback when no custom config is provided.
- Exported slash command item/provider/context types for future consumer-side planner work.

## Impact

Existing Scribe consumers should keep the same behavior by default. Future CleverTask work can use the new provider to show planner-safe commands outside lists and task metadata commands inside list items without hardcoding CleverTask behavior into Scribe.

## References

- https://github.com/clevertask/scribe/blob/main/lib/components/Scribe/index.tsx
- https://github.com/clevertask/scribe/blob/main/lib/components/Scribe/extension/index.ts
- https://github.com/clevertask/scribe/blob/main/lib/components/Scribe/extension/slashCommand/index.ts
- https://github.com/clevertask/scribe/blob/main/lib/components/Scribe/extension/slashCommand/items.tsx

## Validation

- `pnpm fmt:check`
- `pnpm run lint`
- `pnpm run build`

I also ran `pnpm exec tsc -p tsconfig.json --noEmit`; it still reports existing strict-mode issues in `emoji/suggest.ts` and `tableOfContents.ts`, but no slash-command errors after this change.
