### PR TITLE
Approve esbuild build script for pnpm installs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+onlyBuiltDependencies:
+  - esbuild
+
 overrides:
   ajv@>=7.0.0-alpha.0 <8.18.0: ">=8.18.0"
   minimatch@<10.2.1: ">=10.2.1"
+
+strictDepBuilds: true


### PR DESCRIPTION
## Why

Newer pnpm versions can fail installs or publish jobs when a dependency with a build script has not been explicitly approved. Scribe depends on Vite, which depends on `esbuild`, and `esbuild` needs its postinstall script to validate/install the platform binary.

Without this approval, install can fail with:

```txt
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: esbuild@0.27.7
```

## What changed

- Added `esbuild` to `onlyBuiltDependencies` in `pnpm-workspace.yaml`.
- Enabled `strictDepBuilds` so future unapproved build scripts fail explicitly instead of slipping in silently.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm fmt:check`
- `pnpm run lint`
- `pnpm run build`
